### PR TITLE
Added support for overriding the root entry in the routetable

### DIFF
--- a/src/RestMockCore/HttpServer.cs
+++ b/src/RestMockCore/HttpServer.cs
@@ -32,20 +32,19 @@ namespace RestMockCore
                 {
                     app.Run(async context =>
                     {
-                        if (context.Request.Path == @"/")
-                        {
-                            context.Response.ContentType = "text/plain";
-                            await context.Response.WriteAsync("It Works!", Encoding.UTF8);
-                            return;
-                        }
-
                         var route = Config.RouteTable?.LastOrDefault(x => x.IsMatch(context.Request));
-                        if (route == null)
+                        
+                        switch (route)
                         {
-                            context.Response.StatusCode = StatusCodes.Status404NotFound;
-                            context.Response.ContentType = "text/plain";
-                            await context.Response.WriteAsync("Page not found!", Encoding.UTF8);
-                            return;
+                            case null when context.Request.Path == @"/":
+                                context.Response.ContentType = "text/plain";
+                                await context.Response.WriteAsync("It Works!", Encoding.UTF8);
+                                return;
+                            case null:
+                                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                                context.Response.ContentType = "text/plain";
+                                await context.Response.WriteAsync("Page not found!", Encoding.UTF8);
+                                return;
                         }
 
                         if (route.Response.Handler != null)

--- a/tests/RestMockCore.Test/HttpServerTests.cs
+++ b/tests/RestMockCore.Test/HttpServerTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Enumeration;
 using System.Linq;
 
@@ -45,6 +46,24 @@ namespace RestMockCore.Test
             Assert.Equal("It Works!", await defaultResponse.Content.ReadAsStringAsync());
             Assert.Equal(200, (int)defaultResponse.StatusCode);
             Assert.Equal("text/plain", defaultResponse.Content.Headers.GetValues("Content-Type").First());
+            Assert.Throws<InvalidOperationException>(() => _httpClient.GetAsync(_address).RunSynchronously());
+        }
+        
+        [Fact]
+        public async void Server_With_Overridden_Root_Should_Return_Correct_Response()
+        {
+            //Arrange
+            _mockServer = new HttpServer(Port);
+            _mockServer.Config.Get("/").Send("Even this works!");
+            _mockServer.Run();
+
+            //Act
+            var defaultResponse = await _httpClient.GetAsync(_address);
+            _mockServer.Dispose();
+
+            //Assert
+            Assert.Equal("Even this works!", await defaultResponse.Content.ReadAsStringAsync());
+            Assert.Equal(200, (int)defaultResponse.StatusCode);
             Assert.Throws<InvalidOperationException>(() => _httpClient.GetAsync(_address).RunSynchronously());
         }
         


### PR DESCRIPTION
Apologies for the flurry of PRs, I found I also needed the ability to provide an explicit route table entry for '/' in my tests so have added support for this. The previous behaviour remains if no route is provided.